### PR TITLE
Add clojure to unlambda translator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+fns-database.clj
+/target

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ Anonymous functions:
 user=> (run-unlambda (print-number (fn [f x] (f (f x)))))
 **
 ```
-### Evaluation
-
-`run-unlambda` uses external unlambda interpreter for now. To use it you need to get one, e.g. from [here](http://www.madore.org/~david/programs/unlambda/#distrib). And change `unlambda-native-path` var in `translator.clj`.
+Note: basic functions such as +, *, -, 0, 1, 2, true, false and others are not provided, so you need to write them by yourself.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,51 @@ programs, consult the official page on unlambda http://www.madore.org/~david/pro
      ``.*`ci`.@`ci
 ```
 
+## Clojure to unlambda translator
+
+Translate expression in clojure-like syntax to unlamba. Allow to define custom functions that saved in file and stored between sessions.
+
+### Usage
+
+```clojure
+user=> (use '[unlambda-clj.translator :only (defu run-unlambda to-unlambda)])
+```
+
+Translate to unlambda:
+```clojure
+user=> (to-unlambda (.o (.l (.l (.e (.H i))))))
+`.o`.l`.l`.e`.Hi
+```
+Run expression:
+```clojure
+user=> (run-unlambda (.o (.l (.l (.e (.H i))))))
+Hello
+```
+Define custom functions:
+```clojure
+user=> (defu print-number [n] (n .* i))
+user=> (defu 2 [f x] (f (f x)))
+user=> (run-unlambda (print-number 2))
+**
+```
+You can also insert "raw" unlambda code using string. E.g. we can define `delay` and `force` functions to delay evaluation of some function:
+```clojure
+user=> (defu delay [] "d`k")
+user=> (defu force [f] (f i))
+user=> (run-unlambda (delay (print-number 2))
+user=> (run-unlambda (force (delay (print-number 2))))
+**
+```
+
+Anonymous functions:
+```clojure
+user=> (run-unlambda (print-number (fn [f x] (f (f x)))))
+**
+```
+### Evaluation
+
+`run-unlambda` uses external unlambda interpreter for now. To use it you need to get one, e.g. from [here](http://www.madore.org/~david/programs/unlambda/#distrib). And change `unlambda-native-path` var in `translator.clj`.
+
 ## License
 
 Copyright (C) 2012 Thom Chiovoloni

--- a/src/unlambda_clj/core.clj
+++ b/src/unlambda_clj/core.clj
@@ -182,7 +182,7 @@
 
 (defn eval-string [str]
   (binding [*in* (clojure.lang.LineNumberingPushbackReader. (java.io.StringReader. str))]
-    (eval (read) identity)))
+    (repl-eval (read))))
 
 (defn -main  [& args]
   (repl :eval repl-eval

--- a/src/unlambda_clj/core.clj
+++ b/src/unlambda_clj/core.clj
@@ -79,6 +79,10 @@
 (defn read-repl [prompt exit]
   (let [c (.read *in*)] (if (neg? c) exit (do (.unread *in* c) (read)))))
 
+(defn eval-string [str]
+  (binding [*in* (clojure.lang.LineNumberingPushbackReader. (java.io.StringReader. str))]
+    (eval (read) identity)))
+
 (defn -main  [& args]
   (repl :eval #(eval % identity), :read read-repl, :prompt #(print "> "), :need-prompt #(identity true)))
 

--- a/src/unlambda_clj/translator.clj
+++ b/src/unlambda_clj/translator.clj
@@ -20,19 +20,29 @@
     (read-string (slurp db-file))
     {}))
 
-(def fns-db (atom (get-functions-from-db)))
-(def fns-translations (atom {}))
+(def ^{:doc "Atom that contains all user defined functions. It is saved to file on every change in order to restore them later."}
+  fns-db
+  (atom (get-functions-from-db)))
 
+(def ^{:doc "Atom that contains function translations, so we don't translate function to unlambda every time we call it."}
+  fns-translations
+  (atom {}))
+
+; Add watcher to save all functions to file every time we define/undefine function.
 (add-watch fns-db :auto-save
            (fn [_ _ _ value] (spit db-file (pr-str value))))
 
-(defn built-in? [fn]
+(defn built-in?
+  "Check if current function is built-in unlambda function, such as i, k, s, .*"
+  [fn]
   (->> fn str first #{\k \s \i \v \c \d \e \@ \| \. \?} boolean))
 
 (declare translate-fn)
 (declare translate-exp)
 
-(defn get-translation [fn]
+(defn get-translation
+  "Get translation for given function. If function is not defined it will be returned unchanged."
+  [fn]
   (or (@fns-translations fn)
       (if-let [{:keys [args body]} (@fns-db fn)]
         (let [translation (translate-fn args body)]
@@ -40,13 +50,17 @@
           translation)
         fn)))
 
-(defn eliminate-var [exp var]
+(defn eliminate-var
+  "Eliminates variable (argument) from unlambda expression. See http://www.madore.org/~david/programs/unlambda/#lambda_elim"
+  [exp var]
   (mapcat #(cond (= % bq) [bq bq 's]
                  (= % var) ['i]
                  :else [bq 'k %])
           exp))
 
-(defn translate-exp [exp]
+(defn translate-exp
+  "Translates expression to unlambda. Returns sequence of symbols."
+  [exp]
   (cond (coll? exp)
         (let [[f & rst] exp]
           (if (= 'fn f)
@@ -57,33 +71,52 @@
         (string? exp) (map (comp symbol str) exp)
         :else (get-translation exp)))
 
-(defn translate-fn [args body]
+(defn translate-fn
+  "Translated function to unlambda. Translates function body to unlambda and then eliminates all arguments one by one in reverse order."
+  [args body]
   (let [exp (translate-exp body)]
     (reduce eliminate-var
             (if (coll? exp) exp [exp])
             (reverse args))))
 
-(defn to-unlambda-sym [exp]
-  #_(println exp "to" (translate-exp exp))
+(defn to-unlambda-sym
+  "Translates expression to unlambda. Returnes string."
+  [exp]
   (apply str (translate-exp exp)))
 
-(defmacro defu [name args body]
+(defmacro defu
+  "Defines function that will translated to unlambda.
+  Usage:
+  (defu print-number [n] (n .* i)) - define function that
+  prints passed number to standard output."
+  [name args body]
   `(do (swap! fns-db assoc (quote ~name) {:args (quote ~args) :body (quote ~body)})
        (reset! fns-translations {})
        (quote ~name)))
 
-(defmacro undefu [name]
+(defmacro undefu
+  "Undefines function. Deletes it."
+  [name]
   `(do (swap! fns-db dissoc (quote ~name))
        (quote ~name)))
 
 
-(defmacro to-unlambda [exp]
+(defmacro to-unlambda
+  "Handy macro to avoid quoting expression."
+  [exp]
   `(to-unlambda-sym (quote ~exp)))
 
-(defmacro run-unlambda [exp]
+(defmacro run-unlambda
+  "Translates given expression to unlambda and run it.
+  Writes output to *out*.
+  Usage: (run-unlambda (.o (.l (.l (.e (.H i))))))
+  writes \"Hello\" to *out*"
+  [exp]
   `(eval-native (to-unlambda-sym (quote ~exp))))
 
-(defn show-fns []
+(defn show-fns
+  "Prints all user defined functions to *out* with args and bodies"
+  []
   (doseq [[name {:keys [args body]}] @fns-db]
     (println (list name args body))))
 

--- a/src/unlambda_clj/translator.clj
+++ b/src/unlambda_clj/translator.clj
@@ -6,11 +6,14 @@
 
 (def db-file  (java.io.File. "fns-database.clj"))
 
-(def unlambda-native-path "/home/nikelandjelo/unlambda-2.0.0/c-refcnt/unlambda")
+(def unlambda-native-path "/path/to/native/interpreter")
 
 (def bq (symbol "`"))
 
-(defn eval-native [str]
+(defn eval-native
+  "Evaluates unlambda code (string) using native intepreter.
+  Interpreter specified by 'unlambda-native-path' var."
+  [str]
   (->> (shell/sh unlambda-native-path :in str)
        :out
        println))
@@ -112,7 +115,8 @@
   Usage: (run-unlambda (.o (.l (.l (.e (.H i))))))
   writes \"Hello\" to *out*"
   [exp]
-  `(eval-native (to-unlambda-sym (quote ~exp))))
+  `(do (core/eval-string (to-unlambda-sym (quote ~exp)))
+       (println)))
 
 (defn show-fns
   "Prints all user defined functions to *out* with args and bodies"

--- a/src/unlambda_clj/translator.clj
+++ b/src/unlambda_clj/translator.clj
@@ -69,6 +69,7 @@
 
 (defmacro defu [name args body]
   `(do (swap! fns-db assoc (quote ~name) {:args (quote ~args) :body (quote ~body)})
+       (reset! fns-translations {})
        (quote ~name)))
 
 (defmacro undefu [name]

--- a/src/unlambda_clj/translator.clj
+++ b/src/unlambda_clj/translator.clj
@@ -1,0 +1,91 @@
+(ns unlambda-clj.translator
+  (:require [unlambda-clj.core :as core]
+            [clojure.java.shell :as shell]))
+
+
+(def db-file  (java.io.File. "fns-database.clj"))
+
+(def unlambda-native-path "/home/nikelandjelo/unlambda-2.0.0/c-refcnt/unlambda")
+
+(def bq (symbol "`"))
+
+(defn eval-native [str]
+  (->> (shell/sh unlambda-native-path :in str)
+       :out
+       println))
+
+
+
+(defn get-functions-from-db []
+  (if (.exists db-file)
+    (read-string (slurp db-file))
+    {}))
+
+(def fns-db (atom (get-functions-from-db)))
+(def fns-translations (atom {}))
+
+(add-watch fns-db :auto-save
+           (fn [_ _ _ value] (spit db-file (pr-str value))))
+
+(defn built-in? [fn]
+  (->> fn str first #{\k \s \i \v \c \d \e \@ \| \. \?} boolean))
+
+(declare to-unlambda-sym)
+(declare translate-fn)
+
+(defn get-translation [fn]
+  (or (@fns-translations fn)
+      (when-let [{:keys [args body]} (@fns-db fn)]
+        (let [translation (translate-fn args body)]
+          (swap! fns-translations assoc fn translation)
+          translation))))
+
+(defn flatten-exp [exp]
+  (if (coll? exp)
+    (concat (repeat (dec (count exp)) bq)
+            (mapcat flatten-exp exp))
+    [exp]))
+
+(defn substitute-fns [exp]
+  (let [fns @fns-db]
+    (mapcat #(if-let [tran (get-translation %)]
+               tran
+               [%])
+            exp)))
+
+(defn eliminate-var [exp var]
+  (mapcat #(cond (= % bq) [bq bq 's]
+                 (= % var) ['i]
+                 :else [bq 'k %])
+
+          exp))
+
+(defn translate-exp [exp]
+  (substitute-fns (flatten-exp exp)))
+
+(defn translate-fn [args body]
+  (let [exp (translate-exp body)]
+    (reduce eliminate-var exp (reverse args))))
+
+(defn to-unlambda-sym [exp]
+  (apply str (translate-exp exp)))
+
+(defmacro defu [name args body]
+  `(do (swap! fns-db assoc (quote ~name) {:args (quote ~args) :body (quote ~body)})
+       (quote ~name)))
+
+(defmacro undefu [name]
+  `(do (swap! fns-db dissoc (quote ~name))
+       (quote ~name)))
+
+
+(defmacro to-unlambda [exp]
+  `(to-unlambda-sym (quote ~exp)))
+
+(defmacro run-unlambda [exp]
+  `(eval-native (to-unlambda-sym (quote ~exp))))
+
+(defn show-fns []
+  (doseq [[name {args :args}] @fns-db]
+    (println name args)))
+

--- a/test/unlambda_clj/test/translator.clj
+++ b/test/unlambda_clj/test/translator.clj
@@ -15,6 +15,7 @@
 (defu 2 [f x] (f (f x)))
 (defu print [n] (n .* i))
 (defu three-as-str [] "``s``s`ksk``s``s`kski")
+(defu dec [n f x] (n (fn [g h] (h (g f))) (fn [u] x) i))
 
 (deftest test-simple
   (are [result exp] (= result (run exp))
@@ -28,13 +29,21 @@
         "*" (print 1)
         "**" (print (+ 1 1))
         "******" (print (+ 2 (* 2 2)))))
-  (testing "string expression"
-    (is (= "***" (run (print three-as-str))))))
+
+  (testing "fn call in the first position of expression"
+    (is (= "**" (run ((2 .*) i))))))
+
+(deftest test-string-expressions
+  (are [result exp] (= result (run exp))
+       "***" (print three-as-str)
+       "**" (print (+ "i" "i"))))
 
 (deftest test-anonymous-fns
   (are [result exp] (= result (run exp))
        "*" (print (fn [x] x))
-       "**" (print (fn [f x] (f (f x))))))
+       "**" (print (fn [f x] (f (f x))))
+       "***" (print (dec (* 2 2)))))
+
 
 
 

--- a/test/unlambda_clj/test/translator.clj
+++ b/test/unlambda_clj/test/translator.clj
@@ -1,0 +1,42 @@
+(ns unlambda-clj.test.translator
+  (:use [unlambda-clj.translator])
+  (:use [clojure.test])
+  (:require [clojure.string]))
+
+(defmacro run [exp]
+  `(binding [*out* (java.io.StringWriter.)]
+     (run-unlambda ~exp)
+     (clojure.string/trim (str *out*))))
+
+(defu + [n m f x] (n f (m f x)))
+(defu * [n m f] (n (m f)))
+(defu 0 [f x] x)
+(defu 1 [f x] (f x))
+(defu 2 [f x] (f (f x)))
+(defu print [n] (n .* i))
+(defu three-as-str [] "``s``s`ksk``s``s`kski")
+
+(deftest test-simple
+  (are [result exp] (= result (run exp))
+       "*" (.* i)
+       "Hello" (.o (.l (.l (.e (.H i)))))))
+
+(deftest test-defu
+  (testing "s-expression"
+   (are [result exp] (= result (run exp))
+        "*" (print i)
+        "*" (print 1)
+        "**" (print (+ 1 1))
+        "******" (print (+ 2 (* 2 2)))))
+  (testing "string expression"
+    (is (= "***" (run (print three-as-str))))))
+
+(deftest test-anonymous-fns
+  (are [result exp] (= result (run exp))
+       "*" (print (fn [x] x))
+       "**" (print (fn [f x] (f (f x))))))
+
+
+
+
+


### PR DESCRIPTION
Translates clojure expression to unlambda. See README.
For now I use external unlambda interpreter, because I get stackoverflow exceptions on some expressions when using `unlambda-clj.core`. Does `unlambda-clj.core` require some jvm tuning like heap size or something else?
